### PR TITLE
Fixed external monitor issue

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1162,7 +1162,7 @@
 				<key>run-efi-updater</key>
 				<string>No</string>
 				<key>boot-args</key>
-				<string>keepsyms=1 debug=0x100 swd_panic=1 darkwake=0</string>
+				<string>keepsyms=1 debug=0x100 swd_panic=1 darkwake=0 igfxonln=1</string>
 			</dict>
 		</dict>
 		<key>Delete</key>

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Now, a bit of positivity: I got most stuff to work and, for my use case, this is
 
 For DRM, we don't have support (check [this](https://dortania.github.io/OpenCore-Post-Install/universal/drm.html#fixing-drm)) to use with hardware, so for Netflix we need to use Google Chrome, which uses software-powered DRM.
 
-When rebooting or waking the laptop while connected to an HDMI screen, we need to re-plug the HDMI cable or turn the external monitor off and on again. If you happen to find a solution, please create a pull request.
-
 Do not use 00001B59 as AAPL,ig-platform-id since with that not even keyboard or mouse work.
 
 To solve the pink screen on HDMI devices, set this ([this](https://dortania.github.io/OpenCore-Post-Install/gpu-patching/intel-patching/connector.html) is the guide I followed):


### PR DESCRIPTION
All I did was add the `igfxonln=1` command in the boot arguments. According to [WhateverGreen's documentation](https://github.com/acidanthera/WhateverGreen?tab=readme-ov-file#intel-hd-graphics), this forces online status on all displays. Whatever that means, it fixes our issue: now you can reboot and sleep the computer how many times you want.